### PR TITLE
TA-229 Fix issue with wrong Project status transition on rejecting Stage from TO_DO

### DIFF
--- a/core/src/main/java/com/arturjarosz/task/project/status/stage/listener/impl/StageRejectFromToDoListener.java
+++ b/core/src/main/java/com/arturjarosz/task/project/status/stage/listener/impl/StageRejectFromToDoListener.java
@@ -27,7 +27,7 @@ public class StageRejectFromToDoListener implements StageStatusTransitionListene
     public void onStageStatusChange(Project project) {
         if (project.getStatus().equals(ProjectStatus.IN_PROGRESS)
                 && this.hasStagesOnlyInRejectedAndToDoStatus(project)) {
-            this.projectStatusTransitionService.backToToDo(project);
+            this.projectStatusTransitionService.completeWork(project);
         }
     }
 


### PR DESCRIPTION
* After rejected stage from TO_DO on Project in IN_PROGRESS, where there are only Stages in Rejected and Completed
the Project will change status to COMPLETED as well.